### PR TITLE
Fix crash with clients older than 5.14 (on_timer `node`) Fixes #4

### DIFF
--- a/mods/content/tg_nodes/init.lua
+++ b/mods/content/tg_nodes/init.lua
@@ -198,7 +198,8 @@ local function createWallLight(name, des, shape, light_level)
 			core.get_node_timer(pos):start(1.0)
 		end,
 		on_timer = function(pos, elapsed, node, timeout)
-			local power = tg_power.getPower()
+			node = node or core.get_node(pos)
+      local power = tg_power.getPower()
 			if power == false then
 				-- core.log("light should be off")
 				if not string.find(node.name, "off") then


### PR DESCRIPTION
Basically does the `node = node or core.get_node(pos)` that I suggested :D works, as I did the fix on 5.13